### PR TITLE
Add ZNS support using namicorn library

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Currently it supports [Zilliqa Testnet v3.0](https://explorer.zilliqa.com/). We 
 | Send fund | done      |
 | Receive fund address/QRcode | done      |
 | Recent transactions history | done      |
+| ZNS support | done      |
 
 Mainnet support will be available once it is released.
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lockr": "^0.8.5",
     "mini-css-extract-plugin": "0.4.3",
     "moment": "^2.22.2",
+    "namicorn": "0.0.13",
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "password-validator": "^4.1.1",
     "pnp-webpack-plugin": "1.1.0",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -18,6 +18,7 @@
     "page": "integration/background/index.html",
     "persistent": true
   },
+  "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
   "permissions": [
     "storage",
     "unlimitedStorage",

--- a/src/components/SendToken.js
+++ b/src/components/SendToken.js
@@ -17,7 +17,7 @@ import LinearProgress from '@material-ui/core/LinearProgress';
 import { Long, units } from '@zilliqa-js/util';
 
 import { getActivePrivateKey, isAddress } from '../utils/crypto';
-import { createZilliqa, getZilliqaVersion } from '../utils/networks';
+import { createZilliqa, getZilliqaVersion, createNamicorn } from '../utils/networks';
 
 import Transition from './Transition';
 
@@ -37,7 +37,22 @@ class SendToken extends React.Component {
   }
 
   handleAddressChange = event => {
+    const { network, showSnackbar } = this.props;
     this.setState({ [event.target.name]: event.target.value });
+    if(event.target.value.match(/\.zil$/)) {
+      const namicorn = createNamicorn(network);
+      if(namicorn) {
+        const targetName = event.target.name;
+        namicorn.resolve(event.target.value).then(data => {
+          if(data)
+            this.setState({ [targetName]: data.addr.substring(2) });
+          else
+            showSnackbar('ZNS domain not found.');
+        }).catch(err => console.log("Error ", err));
+      } else {
+        console.log('ZNS is not supported on', network);
+      }
+    }
   };
 
   handleAmountChange = event => {

--- a/src/utils/networks.js
+++ b/src/utils/networks.js
@@ -1,5 +1,6 @@
 import { Zilliqa } from '@zilliqa-js/zilliqa';
 import { bytes } from '@zilliqa-js/util';
+import Namicorn from 'namicorn';
 
 const MAINNET = 'MAINNET';
 const TESTNET = 'TESTNET';
@@ -31,6 +32,21 @@ const getNodeUrl = network => {
 
 const createZilliqa = network => {
   return new Zilliqa(getNodeUrl(network));
+};
+
+const createNamicorn = network => {
+  if(isTestnet(network)) {
+    const namicorn = Namicorn.create({
+      debug: false,
+      disableMatcher: true,
+    });
+    namicorn.use(
+      namicorn.middleware.zns({ url: getNodeUrl(network) }),
+    );
+    return namicorn;
+  } else {
+    return null;
+  }
 };
 
 const getZilliqaVersion = async network => {
@@ -82,6 +98,7 @@ export {
   createZilliqa,
   getZilliqaVersion,
   getNetworkName,
+  createNamicorn,
   getViewBlockAddressHistoryAPIURL,
   getViewBlockAddressExplorerURL,
   getViewBlockTXHashExplorerURL,


### PR DESCRIPTION
## Description

Add ZNS domain name resolution on the `SendToken` functionality using namicorn library.

Solves #8 

## Checklist

- [X] Add ZNS name resolution on SendToken screen.
- [X] When a user types a ZNS domain on the `To Address` textfield and it is resolved using namicorn, textfield value is replaced with the resolved address.
- [X] Validate `To Address` is correct (either resolved ZNS domain or address) before the user can send tokens
- [X] Support for testnet only
- [ ] Reverse lookup
